### PR TITLE
Move URLs to napari/napari-workshop-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A JupyterBook template for napari workshops.
 
 **To see the built website, go to https://<your_github_username>.github.io/napari-workshop-template**
 
-**To see a live version where you can execute the notebooks on your browser, use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/melissawm/napari-workshop-template/binder)** (make sure this link points to your own repository!)
+**To see a live version where you can execute the notebooks on your browser, use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/napari/napari-workshop-template/binder)** (make sure this link points to your own repository!)
 
 ## What is this repository?
 

--- a/napari-workshops/_config.yml
+++ b/napari-workshops/_config.yml
@@ -28,7 +28,7 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/melissawm/napari-workshop-template  # Online location of your book
+  url: https://github.com/napari/napari-workshop-template  # Online location of your book
   branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book

--- a/napari-workshops/docs/build_your_workshop.md
+++ b/napari-workshops/docs/build_your_workshop.md
@@ -85,7 +85,7 @@ https://<your-username>.github.io/<workshop-name>
 
 For this template, the built site is at
 
-https://melissawm.github.io/napari-workshop-template
+https://napari.github.io/napari-workshop-template
 
 ## Index your workshop using Zenodo (for citation purposes)
 


### PR DESCRIPTION
Remove all mentions of `melissawm` and move all URLs to napari.