### PR TITLE
Update binder link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A JupyterBook template for napari workshops.
 
 **To see the built website, go to https://<your_github_username>.github.io/napari-workshop-template**
 
-**To see a live version where you can execute the notebooks on your browser, use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/napari/napari-workshop-template/binder)** (make sure this link points to your own repository!)
+**To see a live version where you can execute the notebooks on your browser, use [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/napari/napari-workshop-template/main)** (make sure this link points to your own repository!)
 
 ## What is this repository?
 

--- a/napari-workshops/_config.yml
+++ b/napari-workshops/_config.yml
@@ -30,6 +30,7 @@ bibtex_bibfiles:
 repository:
   url: https://github.com/napari/napari-workshop-template  # Online location of your book
   branch: main  # Which branch of the repository should be used when creating links (optional)
+  path_to_book: "napari-workshops"  # A path to your book's folder, relative to the repository root.
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
Update link to point to branch `main` instead of `binder`. Partially addresses #8 