### PR TITLE
Turn off auto-execution of notebooks

### DIFF
--- a/napari-workshops/_config.yml
+++ b/napari-workshops/_config.yml
@@ -15,7 +15,7 @@ launch_buttons:
 # Force re-execution of notebooks on each build.
 # See https://jupyterbook.org/content/execute.html
 execute:
-  execute_notebooks: "cache"
+  execute_notebooks: "off"
 
 # Define the name of the latex output file for PDF builds
 latex:


### PR DESCRIPTION
Prevents CI errors. Might need to be changed locally for notebooks to be updated.