### PR TITLE
make notebooks executable on Actions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,12 +34,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
+      - name: qt libs
+        uses: tlambert03/setup-qt-libs@v1
       - name: Setup Pages
         uses: actions/configure-pages@v2
-      - name: Build workshop
-        run: |
-          pip install -r requirements.txt
-          jupyter book build napari-workshops
+      - uses: aganders3/headless-gui@v1
+        name: Build workshop
+        with:
+          run: |
+            pip install -r requirements.txt
+            jupyter book build napari-workshops
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:


### PR DESCRIPTION
This PR adds the necessary actions to be able to execute notebooks when creating the GitHub Pages website. This is necessary to allow to use napari in headless mode.