### PR TITLE
[Maint] Add jupyterlab-myst and also update conda env.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,12 +1,11 @@
-name: workshop
+name: napari-workshop
 channels:
   - conda-forge
 dependencies:
   - jupyterlab
   - jupytext
+  - jupyter-book
+  - jupyterlab-myst
   - matplotlib
   - napari
-  - pip
-  - pip:
-    - jupyter-book
-    - napari-animation
+  - napari-animation

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 jupyter-book
 jupyterlab
+jupyterlab-myst
 jupytext
 napari[all]
 napari-animation
 matplotlib
-


### PR DESCRIPTION
In this PR I:
1. add Jupyterlab-myst to the environment and requirements file (closes: https://github.com/napari/napari-workshop-template/issues/25)
It makes it possible to use the nice formatting of admonitions in the rendered notebooks on the web and have then in runnable notebooks in jupyter.
![image](https://github.com/user-attachments/assets/ae1f9a93-af90-4ea3-839d-3f814e6c1bf4)

I also update the environment.yml file to just use conda-forge for all the packages--they same versions are on conda-forge as pip, so there is no need to complicate the installs.