### PR TITLE
Update the environment creation to just use conda and use python 3.11

### DIFF
--- a/napari-workshops/installation.md
+++ b/napari-workshops/installation.md
@@ -98,10 +98,10 @@ as well and you can skip to the next section.
 2. We use an environment to encapsulate the Python tools used for this workshop.
    This ensures that the requirements for this workshop do not interfere with
    your other Python projects. To create the environment (named
-   `napari-tutorial`) and install Python 3.9 in it, enter the following command:
+   `napari-tutorial`) and install Python 3.11 and napari in it, enter the following command:
 
     ```bash
-    conda create -n napari-tutorial python=3.9
+    conda create -n napari-tutorial -c conda-forge python=3.11 napari pyqt jupyterlab
     ```
 
 3. Once the environment setup has finished, activate the environment:
@@ -113,38 +113,28 @@ as well and you can skip to the next section.
     If you successfully activated the environment, you should now see
    `(napari-tutorial)` to the left of your command prompt.
 
-4. Install the workshop dependencies with the commands below.
+4. Install the additional workshop dependencies with the commands below.  
 
-    **If you're on an M1 Mac**:
-
-    ```bash
-    conda install -c conda-forge notebook napari
-    python -m pip install cookiecutter magicgui
-    python -m pip install stardist-napari
-    ```
-
-    Other systems: 
+   For the plugin template:
 
     ```bash
-    conda install -c conda-forge notebook
-    python -m pip install cookiecutter magicgui "napari[all]"
-    python -m pip install stardist-napari
+    conda install -c conda-forge cookiecutter 
     ```
 
-5. If you are on a Mac, please install this one additional dependency.
+   For the `stardist` plugin:
 
-    ```python
-    conda install -c conda-forge python.app
+    ```bash
+    conda install stardist-napari
     ```
 
 6. Test that your notebook installation is working. We will be using notebooks
    for interactive analysis. Enter the command below and it should launch the
-   `jupyter notebook` application in a web browser. Once you've confirmed it
+   `jupyter lab` application in a web browser. Once you've confirmed it
    launches, close the web browser and press `ctrl+c` in the terminal window to
    stop the notebook server.
 
     ```bash
-    jupyter notebook
+    jupyter lab
     ```
 
 7. Test your napari installation. Enter the command below and an empty napari
@@ -156,33 +146,9 @@ as well and you can skip to the next section.
     ```
 
 ````{admonition} Errors launching?
-Sometimes, `napari` installation can fail on an M1 Mac due to mismatching
-dependencies on `pip`.
-
-If you get an error at step 4 above, or can't launch `napari` after
-installation, you should try to delete your `napari-tutorial` environment, and
-follow the installation instructions below.
-
-1. Delete your `napari-tutorial` environment
-
-   ```bash
-   conda activate base
-   conda env remove -n napari-tutorial
-   ```
-
-2. Create your environment and install `napari` from `conda-forge`
-
-   ```bash
-   conda create -y -n napari-tutorial python=3.9 napari
-   ```
-
-3. Then, after creation:
-
-   ```bash
-   conda activate napari-tutorial
-   conda install -c conda-forge notebook
-   pip install cookiecutter magicgui
-   pip install stardist-napari
-   ```
+If you have any issues with installation or launching napari, please feel free to write us a message
+on the
+[napari zulip](https://napari.zulipchat.com/#narrow/stream/212875-general) and
+we will try to help you get unstuck.
 
 ````

--- a/napari-workshops/installation.md
+++ b/napari-workshops/installation.md
@@ -98,20 +98,20 @@ as well and you can skip to the next section.
 2. We use an environment to encapsulate the Python tools used for this workshop.
    This ensures that the requirements for this workshop do not interfere with
    your other Python projects. To create the environment (named
-   `napari-tutorial`) and install Python 3.11 and napari in it, enter the following command:
+   `napari-workshop`) and install Python 3.11 and napari in it, enter the following command:
 
     ```bash
-    conda create -n napari-tutorial -c conda-forge python=3.11 napari pyqt jupyterlab
+    conda create -n napari-workshop -c conda-forge python=3.11 napari pyqt jupyterlab
     ```
 
 3. Once the environment setup has finished, activate the environment:
 
     ```bash
-    conda activate napari-tutorial
+    conda activate napari-workshop
     ```
 
     If you successfully activated the environment, you should now see
-   `(napari-tutorial)` to the left of your command prompt.
+   `(napari-workshop)` to the left of your command prompt.
 
 4. Install the additional workshop dependencies with the commands below.  
 
@@ -124,7 +124,7 @@ as well and you can skip to the next section.
    For the `stardist` plugin:
 
     ```bash
-    conda install stardist-napari
+    conda install -c conda-forge stardist-napari
     ```
 
 6. Test that your notebook installation is working. We will be using notebooks

--- a/napari-workshops/make_a_simple_plugin.md
+++ b/napari-workshops/make_a_simple_plugin.md
@@ -66,7 +66,7 @@ tutorial. This environment includes all of the packages required to make your
 plugin (including `cookiecutter`).
 
 ```bash
-conda activate napari-tutorial
+conda activate napari-workshop
 ```
 
 In this next step, we will use `cookiecutter` to create a directory for our
@@ -463,7 +463,7 @@ where = src
 
 ## Testing/Installing your plugin
 To test and use our plugin, we need to install it in our Python environment.
-First, return to your terminal and verify you have the `napari-tutorial`
+First, return to your terminal and verify you have the `napari-workshop`
 environment activated. Then, navigate to the directory that you created with the
 cookiecutter. For example, if you named your plugin `napari-spot-detector`, you
 would enter the following into your terminal.


### PR DESCRIPTION
In this PR I update the environment creation part of the installation instructions to:
1. just use conda, rather than mix and match with pip
2. eliminate special M1 instructions, which aren't needed anymore
3. use jupyterlab to match the rest of the materials
4. use napari-workshop as the name of the env for clarity and consistency