### PR TITLE
[Maint] go back to ubuntu 22.04 runner

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,7 +26,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
CI is failing: https://github.com/napari/napari-workshop-template/actions/runs/11293776726/job/31412703767
This is due to ubuntu-latest runner switching from 22.04 to 24.04
Work around for: https://github.com/tlambert03/setup-qt-libs/issues/65