### PR TITLE
Update the noteboooks/index.md to have ToC first and link to notebook_setup

### DIFF
--- a/napari-workshops/notebooks/index.md
+++ b/napari-workshops/notebooks/index.md
@@ -1,13 +1,18 @@
 # Notebooks
 
-```{note}
+We encourage you to follow along with your own, fresh notebook, using the executed and rendered notebooks included in this repository only as a guide.
+
+## Rendered notebooks
+
+```{tableofcontents}
+```
+
+````{note}
 In this repository, all notebooks have been converted to MyST Markdown files
 (with a `.md` extension) since this format is easier to visualize on GitHub.
 This also makes it easier to view differences between versions of the notebooks
 on the GitHub interface. To open these files as Jupyter Notebooks, you need to
-have the Jupytext package installed (this will be installed automatically if you
-run `python -m pip install -r requirements.txt` or
-`conda create -f environment.yml` from this repository as outlined in [](../installation).)
+have the Jupytext package installed, see [the notebook setup page.](../notebook_setup).)
 
 In the Jupyter notebook interface, if you right-click any of the `.md` files in
 this folder now, you should see an option that says "Open with -> Notebook"
@@ -21,9 +26,4 @@ jupytext --to ipynb <notebook_file>.md
 ```
 
 in the command line.
-```
-
-## Contents
-
-```{tableofcontents}
-```
+````


### PR DESCRIPTION
This PR depends on: https://github.com/napari/napari-workshop-template/pull/32

I feel like having the ToC at the top is more natural -- there will be be people just browsing and not opening/running the notebooks. Then in the Note, we can refer to the updated notebook_setup for more detailed instructions.