### PR TITLE
add split-up spot detection notebooks

### DIFF
--- a/napari-workshops/_toc.yml
+++ b/napari-workshops/_toc.yml
@@ -19,4 +19,9 @@ chapters:
   - file: notebooks/segmenting_and_measuring_nuclei_stardist
   - file: notebooks/manual_annotation
   - file: notebooks/custom_colormaps
+  - header: "Alternative Spot Detection Notebooks"
+    - sections:
+      - file: notebooks/spot_detection_basics
+      - file: notebooks/spot_detection_functions
+
 - file: make_a_simple_plugin

--- a/napari-workshops/notebooks/spot_detection_basic.md
+++ b/napari-workshops/notebooks/spot_detection_basic.md
@@ -176,12 +176,12 @@ perform the blob detection.
 from skimage.feature import blob_log
 
 # detect the spots on the filtered image
+```python
 blobs_log = blob_log(
-    high_passed_spots,
-    max_sigma=3,
+    high_passed_spots, max_sigma=3,
     threshold=None,  # use a relative threshold instead
-    threshold_rel=0.2
-)
+    threshold_rel=0.2)
+```
     
 # convert the output of the blob detector to the 
 # desired points_coords and sizes arrays

--- a/napari-workshops/notebooks/spot_detection_basic.md
+++ b/napari-workshops/notebooks/spot_detection_basic.md
@@ -1,0 +1,270 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# Exploratory analysis: spot detection
+
+## Overview
+In this activity, we will perform spot detection on some in situ sequencing data
+([Feldman and Singh et al., Cell, 2019](https://www.cell.com/cell/fulltext/S0092-8674(19)31067-0s)).
+In doing so, we will combine methods from [scipy](https://www.scipy.org/) and
+[scikit-image](https://scikit-image.org/). The goal is to familiarize you with
+performing analysis that integrates the scientific python ecosystem and napari.
+
+## Data source
+
+The data were downloaded from the
+[OpticalPooledScreens github repository](https://github.com/feldman4/OpticalPooledScreens).
+
+## Next steps
+
+Following this activity, we will use the workflow generated in this activity to
+create a napari spot detection widget or even plugin.
+
+## `binder` setup
+
+```{code-cell} ipython3
+:tags: [remove-output]
+
+# this cell is required to run these notebooks on Binder. Make sure that you also have a desktop tab open.
+import os
+if 'BINDER_SERVICE_HOST' in os.environ:
+    os.environ['DISPLAY'] = ':1.0'
+```
+
+## Screenshots
+As previously, we will use the `nbscreenshot` to document our work in the notebook as we go along.
+As a reminder, the usage is: 
+
+```Python
+nbscreenshot(viewer)
+```
+
+## Load the data
+
+In the cells below load the data using the scikit-image `imread()` function. For
+more information about the `imread()` function, please see the [scikit-image docs](https://scikit-image.org/docs/dev/api/skimage.io.html#skimage.io.imread). We are loading two images:
+
+- `nuclei`: an image of cell nuclei
+- `spots`: an image of in situ sequencing spots
+
+```{code-cell} ipython3
+from skimage import io
+
+nuclei_url = 'https://raw.githubusercontent.com/kevinyamauchi/napari-spot-detection-tutorial/main/data/nuclei_cropped.tif'
+nuclei = io.imread(nuclei_url)
+
+spots_url = 'https://raw.githubusercontent.com/kevinyamauchi/napari-spot-detection-tutorial/main/data/spots_cropped.tif'
+spots = io.imread(spots_url)
+```
+
+## View the data
+
+To view our data, we will create a napari viewer and then we will add the images to the viewer
+via the viewer's `add_image()` method. We will also import the `nbscreenshot` utility.
+
+```{code-cell} ipython3
+import napari
+from napari.utils import nbscreenshot
+
+# create the napari viewer
+viewer = napari.Viewer()
+
+# add the nuclei image to the viewer
+viewer.add_image(nuclei, colormap='green')
+
+# add the spots image to the viewer
+viewer.add_image(spots, colormap='magenta', blending='additive')
+```
+
+After loading the data, inspect it in the viewer and adjust the
+layer settings to your liking (e.g., contrast limits, colormap). 
+You can pan/zoom around the image by click/dragging to pan and scrolling with your
+mousewheel or trackpad to zoom.
+
+```{tip}
+You can adjust a layer's opacity to see the change how much you see of the
+layers that are "under" it.
+```
+For example, for better contrast you could choose an inverted colormap and minimum blending.
+
+```{code-cell} ipython3
+viewer.layers['nuclei'].colormap = 'I Forest'
+viewer.layers['nuclei'].blending = 'minimum'
+viewer.layers['spots'].colormap = 'I Orange'
+viewer.layers['spots'].blending = 'minimum'
+```
+
+Once you are satisfied, you can print the output of any manual changes and then take a screenshot of the viewer.
+
+```{code-cell} ipython3
+# example of printing the nuclei layer visualization params
+print('Colormap: ', viewer.layers['nuclei'].colormap.name)
+print('Contrast limits: ', viewer.layers['nuclei'].contrast_limits)
+print('Opacity: ', viewer.layers['nuclei'].opacity)
+print('Blending: ', viewer.layers['nuclei'].blending)
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## Create an image filter
+
+If you look carefull at the `spots` layer, you will notice that it contains background and
+autofluorescence from the cells. It may help to just look at the single channel.
+
+```{code-cell} ipython3
+viewer.layers['nuclei'].visible = False
+```
+
+To improve spot detection, we will apply a high pass filter to improve the contrast of the spots.
+
+A simple way to achieve this is to:
+1. blur the image with a Gaussian, which removes high-frequency information—this is why we use it for denoising.
+2. subtract the blurred image from the original.
+
+Lets try this using the `gaussian_filter` from `scipy` with a sigma of 2 px and lets clip any negative values:
+
+```{code-cell} ipython3
+import numpy as np
+from scipy import ndimage as ndi
+
+
+low_pass = ndi.gaussian_filter(spots, 2)
+high_passed_spots = (spots - low_pass).clip(0)
+```
+
+Let's visualize both versions of the data.
+
+```{code-cell} ipython3
+viewer.add_image(low_pass, colormap="I Forest", blending="minimum")
+viewer.add_image(high_passed_spots, colormap="I Blue", blending="minimum")
+```
+
+Toggle the visibility of the 3 spots layers to get a better sense of the effect of our filter.
+Let's hide the `low_pass` and take a screenshot for documentation.
+
+```{code-cell} ipython3
+viewer.layers['low_pass'].visible = False
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## Detect spots
+
+Next, we will use one of the blob detection algorithms from sci-kit image to
+perform the blob detection.
+
+```{tip}
+- See the [blob detection tutorial from scikit-image](https://scikit-image.org/docs/stable/auto_examples/features_detection/plot_blob.html). We recommend the [blob_log detector](https://scikit-image.org/docs/stable/api/skimage.feature.html#skimage.feature.blob_log), but feel free to experiment!
+- See the "Note" from the blob_log docs: "The radius of each blob is approximately $\sqrt{2}\sigma$ for a 2-D image"
+```
+
+```{code-cell} ipython3
+from skimage.feature import blob_log
+
+# detect the spots on the filtered image
+blobs_log = blob_log(
+    high_passed_spots,
+    max_sigma=3,
+    threshold=None, # use a relative threshold instead
+    threshold_rel=0.2
+)
+    
+# convert the output of the blob detector to the 
+# desired points_coords and sizes arrays
+# (see the docstring for details)
+spot_coords = blobs_log[:, 0:2]
+spot_sizes = 2 * np.sqrt(2) * blobs_log[:, 2]
+```
+
+To visualize the results, add the spots to the viewer as a
+[Points layer](https://napari.org/stable/tutorials/fundamentals/points.html). If you
+would like to see an example of using a points layer, see
+[this example](https://napari.org/gallery/add_points.html).
+
+```{code-cell} ipython3
+# add the detected spots to the viewer as a Points layer
+viewer.add_points(spot_coords, size=spot_sizes)
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+Let's zoom in for a better look. You can explore interactively in the viewer and then you can explicitly
+set the center of the field of view and the zoom factor.
+
+```{code-cell} ipython3
+viewer.camera.center = (200, 270)
+viewer.camera.zoom = 8
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## Optional: using Points layer `properties`
+
+`properties` is a table associated with a Points layer that can store additional data associated with
+a data point. It has one row per data element (Point) and one column per feature. Importantly,
+napari can not only display the values of associated features in the status bar, but also use them for
+styling, e.g. for `face_color`. For more information, see the [Points layer guide](https://napari.org/stable/howtos/layers/points.html#setting-point-edge-and-face-color-with-properties).
+
+```{note}
+napari plans to deprecate `properties` in favor of `features` in a future release, but for the time being
+the documentation for `properties` is superior, so we use that here. Note that some examples in the Gallery
+have been updated to use `features`, but for the purposes of these simple examples you can replace
+`features` with `properties` or vice versa.
+```
+
+Let's use the `properties` dictionary to store the intensity value of the image at the coordinate of point
+and then we can encode the color of the point marker using that value.
+
+First let's get an array of the pixel values of the original data array at the coordinates of our detected
+points.
+
+```{code-cell} ipython3
+# convert coordinates into a tuple that can be used to index the image data
+tuple_of_spots_as_indexes = tuple(np.round(spot_coords).astype(int).T)
+intensities = viewer.layers['spots'].data[tuple_of_spots_as_indexes]
+```
+
+Now we will set the `properties` table of our Points layer—we could have done this when we constructed the layer.
+
+```{code-cell} ipython3
+viewer.layers['spot_coords'].properties = {'intensity': intensities}
+```
+
+Now when you mouseover a point, you should see the corresponding intensity value in the status bar.
+Next let's hook up the coloring to color the Points by intensity.
+
+```{code-cell} ipython3
+viewer.layers['spot_coords'].face_color = 'intensity'
+viewer.layers['spot_coords'].face_colormap = 'viridis'
+viewer.layers['spot_coords'].face_color_mode = 'colormap'
+viewer.layers['spot_coords'].refresh_colors()
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## Conclusion
+In this activity, we have developed done the exploratory analysis for spot detection
+using a combination of Jupyter notebook, scipy, scikit-image, and napari. In the
+next activity, we will convert this workflow into a spot detection function to make 
+it easier to explore the effect of parameters. Then, we will turn that into a napari widget
+using `magicgui`.

--- a/napari-workshops/notebooks/spot_detection_basic.md
+++ b/napari-workshops/notebooks/spot_detection_basic.md
@@ -216,21 +216,20 @@ viewer.camera.zoom = 8
 nbscreenshot(viewer)
 ```
 
-## Optional: using Points layer `properties`
+## Optional: using Points layer `features`
 
-`properties` is a table associated with a Points layer that can store additional data associated with
-a data point. It has one row per data element (Point) and one column per feature. Importantly,
-napari can not only display the values of associated features in the status bar, but also use them for
-styling, e.g. for `face_color`. For more information, see the [Points layer guide](https://napari.org/stable/howtos/layers/points.html#setting-point-edge-and-face-color-with-properties).
+`features` is a table associated with a Points layer that can store additional data associated with
+a data point. It has one row per data element (Point) and one column per feature. This would enable you 
+to add other attributes like `volume` or `maximum-intensity` should you calculate those for each cell. 
+Importantly, napari can not only display the values of associated features in the status bar, but 
+also use them for styling, e.g. for `face_color`. For more information, see the 
+[Points layer guide](https://napari.org/stable/howtos/layers/points.html#using-the-points-features-table), 
+[the Points annotation tutorial](https://napari.org/stable/tutorials/annotation/annotate_points.html) 
+or the ["Add points with features" Gallery example](https://napari.org/stable/gallery/add_points_with_features.html#sphx-glr-gallery-add-points-with-features-py).
 
-```{note}
-napari plans to deprecate `properties` in favor of `features` in a future release, but for the time being
-the documentation for `properties` is superior, so we use that here. Note that some examples in the Gallery
-have been updated to use `features`, but for the purposes of these simple examples you can replace
-`features` with `properties` or vice versa.
-```
 
-Let's use the `properties` dictionary to store the intensity value of the image at the coordinate of point
+
+Let's use the `features` dictionary to store the intensity value of the image at the coordinate of point
 and then we can encode the color of the point marker using that value.
 
 First let's get an array of the pixel values of the original data array at the coordinates of our detected
@@ -242,10 +241,10 @@ tuple_of_spots_as_indexes = tuple(np.round(spot_coords).astype(int).T)
 intensities = viewer.layers['spots'].data[tuple_of_spots_as_indexes]
 ```
 
-Now we will set the `properties` table of our Points layer—we could have done this when we constructed the layer.
+Now we will set the `features` table of our Points layer—we could have done this when we constructed the layer.
 
 ```{code-cell} ipython3
-viewer.layers['spot_coords'].properties = {'intensity': intensities}
+viewer.layers['spot_coords'].features = {'intensity': intensities}
 ```
 
 Now when you mouseover a point, you should see the corresponding intensity value in the status bar.

--- a/napari-workshops/notebooks/spot_detection_basic.md
+++ b/napari-workshops/notebooks/spot_detection_basic.md
@@ -130,7 +130,8 @@ viewer.layers['nuclei'].visible = False
 To improve spot detection, we will apply a high pass filter to improve the contrast of the spots.
 
 A simple way to achieve this is to:
-1. blur the image with a Gaussian, which removes high-frequency information—this is why we use it for denoising.
+1. blur the image with a Gaussian, which removes high-frequency information (small features, including
+our spots)—this is why we use it for denoising.
 2. subtract the blurred image from the original.
 
 Lets try this using the `gaussian_filter` from `scipy` with a sigma of 2 px and lets clip any negative values:

--- a/napari-workshops/notebooks/spot_detection_basic.md
+++ b/napari-workshops/notebooks/spot_detection_basic.md
@@ -120,7 +120,7 @@ nbscreenshot(viewer)
 
 ## Create an image filter
 
-If you look carefull at the `spots` layer, you will notice that it contains background and
+If you look carefully at the `spots` layer, you will notice that it contains background and
 autofluorescence from the cells. It may help to just look at the single channel.
 
 ```{code-cell} ipython3
@@ -164,7 +164,7 @@ nbscreenshot(viewer)
 
 ## Detect spots
 
-Next, we will use one of the blob detection algorithms from sci-kit image to
+Next, we will use one of the blob detection algorithms from scikit-image to
 perform the blob detection.
 
 ```{tip}
@@ -179,7 +179,7 @@ from skimage.feature import blob_log
 blobs_log = blob_log(
     high_passed_spots,
     max_sigma=3,
-    threshold=None, # use a relative threshold instead
+    threshold=None,  # use a relative threshold instead
     threshold_rel=0.2
 )
     

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -196,9 +196,9 @@ viewer.window.remove_dock_widget("all")
 ```
 
 ```{code-cell} ipython3
-@magicgui(auto_call=True,
-            sigma={"widget_type": "FloatSlider", "min": 0, "max": 20}
-         )
+@magicgui(
+    auto_call=True, 
+    sigma={"widget_type": "FloatSlider", "min": 0, "max": 20})
 def gaussian_high_pass(
         image: "napari.types.ImageData", sigma: float = 2
         ) -> "napari.types.ImageData":
@@ -280,11 +280,11 @@ from skimage.feature import blob_log
 
 @magicgui
 def detect_spots(
-    image: "napari.layers.Image",
-    high_pass_sigma: float = 2,
-    spot_threshold: float = 0.2,
-    blob_sigma: float = 2
-    )->"napari.types.LayerDataTuple":
+        image: "napari.layers.Image",
+        high_pass_sigma: float = 2,
+        spot_threshold: float = 0.2,
+        blob_sigma: float = 2
+        )->"napari.types.LayerDataTuple":
     """Apply a gaussian high pass filter to an image.
 
     Parameters

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -1,0 +1,408 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: Python 3 (ipykernel)
+  language: python
+  name: python3
+---
+
+# From workflow to widget: customizing napari
+
+The napari application uses a backend for the graphical user interface (GUI) called [Qt](https://doc.qt.io). A key feature of this framework is the use of [widgets](https://doc.qt.io/qt-6/qtwidgets-index.html), which are composable, basic UI elements. napari not only utilizes these for its UI, but also enables you can add your own as `dockable` elements. In fact, the layer controls, layer list, and napari console are all such dockable containers of Qt widgets.
+
+There are a number of ways to go about creating your own widgets, you can see [an in-depth overview in the napari documentation](https://napari.org/dev/howtos/extending/magicgui.html). By far the simplest is to rely on the fact that napari supports the use of [`magicgui`](https://pyapp-kit.github.io/magicgui/), a Python library for quick and easy building of GUIs. A key feature of `magicgui` is autogeneration of GUIs from functions and dataclasses, by mapping Python type hints to widgets.
+
+In this module, we will implement elements of our previous workflow as functions and then use [`magicgui.magicgui`](https://pyapp-kit.github.io/magicgui/api/magicgui/#magicguimagicgui) decorator on those functions to return us compound widgets that we can use to make exploring the parameters easier in the GUI. For a nice overview of the `magicgui` decorators, see [the official documentation](https://pyapp-kit.github.io/magicgui/decorators/).
+
+Let's get everything set up, based on the previous notebook:
+
+```{code-cell} ipython3
+from skimage import io
+
+nuclei_url = 'https://raw.githubusercontent.com/kevinyamauchi/napari-spot-detection-tutorial/main/data/nuclei_cropped.tif'
+nuclei = io.imread(nuclei_url)
+
+spots_url = 'https://raw.githubusercontent.com/kevinyamauchi/napari-spot-detection-tutorial/main/data/spots_cropped.tif'
+spots = io.imread(spots_url)
+```
+
+```{code-cell} ipython3
+import napari
+from napari.utils import nbscreenshot
+
+# create the napari viewer
+viewer = napari.Viewer()
+
+# add the nuclei image to the viewer
+viewer.add_image(nuclei, colormap = 'I Forest', blending = 'minimum')
+
+# add the spots image to the viewer
+viewer.add_image(spots, colormap = 'I Orange', blending='minimum')
+```
+
+Now let's write a function that takes an array and a `sigma` value and performs the 
+high-pass operation.
+
+```{code-cell} ipython3
+import numpy as np
+from scipy import ndimage as ndi
+
+def gaussian_high_pass(image, sigma):
+    low_pass = ndi.gaussian_filter(image, sigma)
+    high_passed_im = (image - low_pass).clip(0)
+    
+    return high_passed_im
+```
+
+We can test our function, in similar fashion as before:
+
+```{code-cell} ipython3
+high_passed_spots = gaussian_high_pass(spots, 2)
+
+viewer.add_image(high_passed_spots, colormap="I Blue", blending="minimum")
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## Obtaining a basic widget using the `@magicgui` decorator
+
+Now lets modify the function slightly, by providing type annotations and a docstring, to 
+leverage napari `magicgui` integration.
+
+````{tip}
+A brief note about type hints:  
+Type hints are not enforced at runtime, **but** they can still raise `NameError` exceptions if not defined or imported.
+To avoid that, we are putting the napari types in quotes to make them "forward references", because we have
+not imported them. Alternatively, we could have imported them. A third option is to import:
+
+```python
+from __future__ import annotations 
+```
+
+This would permit us to drop the quotes from the type hints.  
+For more information, see the official Python documentation for: 
+[type hints in Python](https://peps.python.org/pep-0484/), [forward references](https://peps.python.org/pep-0484/#forward-references),and [annotations](https://peps.python.org/pep-0563/).
+
+````
+
+```{code-cell} ipython3
+from magicgui import magicgui
+
+@magicgui
+def gaussian_high_pass(image: "napari.types.ImageData", sigma: float = 2)->"napari.types.ImageData":
+    """Apply a gaussian high pass filter to an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        The image to be filtered.
+    sigma : float
+        The sigma (width) of the gaussian filter to be applied.
+        The default value is 2.
+    
+    Returns
+    -------
+    high_passed_im : np.ndarray
+        The image with the high pass filter applied
+    """
+    low_pass = ndi.gaussian_filter(image, sigma)
+    high_passed_im = (image - low_pass).clip(0)
+    
+    return high_passed_im
+```
+
+We have our `magicgui` decorated function and we've annotated it with the napari types.
+Now, the object `gaussian_high_pass` is both a (compound) widget and a callable function. 
+Let's add it to the viewer.
+
+```{code-cell} ipython3
+viewer.window.add_dock_widget(gaussian_high_pass)
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+Notice that because we told `magicgui` that our function will use not just any numpy array, but 
+specifically `ImageData`—the data of an Image layer—and that it will also return that, `magicgui`
+generated UI widgets for selecting an Image layer--if you add another layer type, it won't show
+up in the dropdown!
+Press the `Run` button and you will see that a new Image layer is added with the results of our
+function—again thanks to autogeneration from `magicgui`.
+
+```{code-cell} ipython3
+:tags: ["hide-output"]
+
+# we'll call the widget to simulate clicking `Run`
+gaussian_high_pass(viewer.layers['spots'].data)
+```
+
+Note that we are just returning `ImageData`, so there is no information passed about colormaps, blending, etc. If we want to specify that, we would need to annotate as [`LayerDataTuple`](https://napari.org/stable/guides/magicgui.html#returning-napari-types-layerdatatuple). (We will do this in the next example.)
+For now you will need to manually or programmatically set any colormap/blending settings. (Let's also hide the previous filtering output.)
+
+```{code-cell} ipython3
+viewer.layers[-1].blending = "minimum"
+viewer.layers[-1].colormap = "I Blue"
+viewer.layers['high_passed_spots'].visible = False
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+However, if you press `Run` again, the data for that layer will be updated in place, so
+you can change the `sigma` value and see the updated result.
+
+```{tip}
+Hover over the labels `image` and `sigma` -- the names of the parameters we passed to the function.
+You should see tooltips with the docstring information! How cool is that?
+```
+
+Our `gaussian_high_pass` object *is the widget*, so we can easily get the value of the current setting:
+
+```{code-cell} ipython3
+gaussian_high_pass.sigma.value
+```
+
+At the same time, `gaussian_high_pass` remains a callable function. Let's call it normally, to check 
+that the function is still working as expected. Remember, type hints are not enforced by Python at runtime, 
+so nothing should have changed.
+
+```{code-cell} ipython3
+test_output = gaussian_high_pass(spots, 2)
+test_output.shape
+```
+
+This means that if you have a script or module you can import the function and use it as normally
+*or* use it as a widget in napari.
+
+Let's make the the widget more dynamic and user-friendly, by giving `magicgui` some extra information.
+Let's ask for a slider for the `sigma` parameter and lets have the function be auto-called
+when the slider is changed.
+
+But first, lets remove the previous widget.
+
+```{code-cell} ipython3
+viewer.window.remove_dock_widget("all")
+```
+
+```{code-cell} ipython3
+@magicgui(auto_call=True,
+            sigma={"widget_type": "FloatSlider", "min": 0, "max": 20}
+         )
+def gaussian_high_pass(image: "napari.types.ImageData", sigma: float = 2)->"napari.types.ImageData":
+    """Apply a gaussian high pass filter to an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        The image to be filtered.
+    sigma : float
+        The sigma (width) of the gaussian filter to be applied.
+        The default value is 2.
+    
+    Returns
+    -------
+    high_passed_im : np.ndarray
+        The image with the high pass filter applied
+    """
+    low_pass = ndi.gaussian_filter(image, sigma)
+    high_passed_im = (image - low_pass).clip(0)
+    
+    return high_passed_im
+```
+
+```{code-cell} ipython3
+viewer.window.add_dock_widget(gaussian_high_pass)
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+Now you can play with the slider until you get the effect you want in the GUI and then return the value:
+
+```{code-cell} ipython3
+gaussian_high_pass.sigma.value
+```
+
+Or you can *set the value*:
+
+```{code-cell} ipython3
+gaussian_high_pass.sigma.value = 3
+```
+
+```{code-cell} ipython3
+nbscreenshot(viewer)
+```
+
+## A more complex example
+
+Finally, lets make a widget for the whole workflow as a function. We will need to write a function
+and then properly annotate it such that `magicgui` can generate the widgets. This time we are also
+starting with image layer (data), but then we want a Points layer with points. We could again return 
+just the layer data using `napari.types.PointsData`. But lets get a nicer Points layer instead, so 
+we will return a LayerDataTuple.  
+
+If `detect_spots()` returns a `LayerDataTuple`, napari will add a *new layer* to
+the viewer using the data in the `LayerDataTuple`. Briefly:
+- The layer data tuple should be: `(layer_data, layer_metadata, layer_type)`
+- `layer_data`: the data to be displayed in the new layer (i.e., the points
+      coordinates)
+- `layer_metadata`: the display options for the layer stored as a
+      dictionary. Some options to consider: `symbol`, `size`, `face_color`
+- `layer_type`: the name of the layer type as a string—in this case `'Points'`  
+
+For more information on using the `LayerDataTuple` type, please see [the documentation](https://napari.org/stable/guides/magicgui.html#returning-napari-types-layerdatatuple).
+
+Also let's change the `image` argument type hint to `ImageLayer` so that we can access more
+properties if we'd like or be able to more easily set the value programmatically.
+
+```{code-cell} ipython3
+# again lets remove the previous widget
+viewer.window.remove_dock_widget("all")
+```
+
+```{code-cell} ipython3
+import numpy as np
+from skimage.feature import blob_log
+
+@magicgui
+def detect_spots(
+    image: "napari.layers.Image",
+    high_pass_sigma: float = 2,
+    spot_threshold: float = 0.2,
+    blob_sigma: float = 2
+    )->"napari.types.LayerDataTuple":
+    """Apply a gaussian high pass filter to an image.
+
+    Parameters
+    ----------
+    image : np.ndarray
+        The image in which to detect the spots.
+    high_pass_sigma : float
+        The sigma (width) of the gaussian filter to be applied.
+        The default value is 2.
+    spot_threshold : float
+        The relative threshold to be passed to the blob detector.
+        The default value is 0.2.
+    blob_sigma: float
+        The expected sigma (width) of the spots. This parameter
+        is passed to the "max_sigma" parameter of the blob
+        detector.
+    
+    Returns
+    -------
+    points_coords : np.ndarray
+        An NxD array with the coordinate for each detected spot.
+        N is the number of spots and D is the number of dimensions.
+    sizes : np.ndarray
+        An array of size N, where N is the number of detected spots
+        with the diameter of each spot.
+    
+    """
+    # filter the image layer data
+    filtered_spots = gaussian_high_pass(image.data, high_pass_sigma)
+
+    # detect the spots on the filtered image
+    blobs_log = blob_log(
+        filtered_spots,
+        max_sigma=blob_sigma,
+        threshold=None,
+        threshold_rel=spot_threshold
+    )
+    
+    # convert the output of the blob detector to the 
+    # desired points_coords and sizes arrays
+    # (see the docstring for details)
+    points_coords = blobs_log[:, 0:2]
+    sizes = 2 * np.sqrt(2) * blobs_log[:, 2]
+
+    return (points_coords, {"size": sizes, "face_color": "red"}, "Points")
+```
+
+```{code-cell} ipython3
+viewer.window.add_dock_widget(detect_spots)
+```
+
+```{code-cell} ipython3
+:tags: ["hide-output"]
+
+# let's call the widget/function to simulate pressing run
+detect_spots(viewer.layers['spots'])
+```
+
+```{code-cell} ipython3
+# lets set the dropdown value for the screenshot
+detect_spots.image.value = viewer.layers['spots']
+
+# and lets zoom in a bit
+viewer.camera.center = (200, 270)
+viewer.camera.zoom = 8
+nbscreenshot(viewer)
+```
+
+```{tip}
+In this notebook we used the `@magicgui` decorator, which turned out function into both a function
+and a widget. Another similar option is the `@magic_factory` decorator. This one *does not return a widget instance immediately*. Instead, it turns out function into a "widget factory function" that can be called to *create a widget instance*. This can be more convenient in many cases, if you are writing a library or package where someone else will be instantiating your widget.  
+One additional important—and useful!—distinction is that `@magic_factory` gains the `widget_init` keyword argument, which will be called with the new widget each time the factory function is called.
+For more details, on the two `magicgui` decorators, see [the official documentation](https://pyapp-kit.github.io/magicgui/decorators/).
+```
+
+## Custom keybindings
+
+napari has extensive keyboard shortcuts that can be customized in the Preferences/Settings GUI.
+However, it also enables you to bind key-press events to custom callback functions. Again, the 
+napari implementation (`bind_key`) is smart, so arguments like the viewer getting the key press or the current
+selected layer of a given time will be passed to your function.
+
+Lets try a simple example, to get the number of Points returned by our detector when we press
+a key binding. For this, we will want the `bind_key` decorator to pass in a selected Points layer
+as an argument to our function that will return the number of detected spots.
+
+```{code-cell} ipython3
+from napari.layers import Points
+
+@Points.bind_key("Shift-D")
+def print_number_of_points(points_layer: "napari.layers.Points"):
+    print("Detected points: ", len(points_layer.data))
+
+```
+
+Give it a shot in the viewer, you should get a print statement in the notebook, when you press the 
+keybinding with a Points layer selected, but not with any other layer type.
+
+```{tip}
+We used `print`, so the output ends up in the notebook (or the terminal, REPL, etc.). To get something visible in the 
+viewer itself, you can use [`napari.utils.notifications.show_info`](https://napari.org/dev/api/napari.utils.notifications.html).
+However, be aware that this won't work when napari was launched from a Jupyter notebook (hopefully fixed in napari 0.5.0): nothing will
+happen.
+```
+
+Let's call the function to trigger it for the notebook:
+```{code-cell} ipython3
+print_number_of_points(viewer.layers['Points'])
+```
+
+```{important}
+At the moment, `bind_key` shortcuts cannot overwrite napari builtin shortcuts, even with `overwrite=True`.
+Worse yet, this will silently fail, because the builtin napari keybinding *will* trigger.
+```
+
+There are actually a number of other events that you can connect callbacks to, other than just key presses.
+For more information, see the [napari events documentation](https://napari.org/stable/howtos/connecting_events.html).
+
+
+## Conclusions
+
+We've now seen how to how to extend the viewer with custom GUI functionality: widgets and keybindings. 
+By using these concepts you can making analyses even more interactive, particularly exploratory/human-in-the-loop
+analysis. Additionally, the approach described here, using `magicgui`, can also be directly used to create
+a plugin to share with the world.

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -197,8 +197,9 @@ viewer.window.remove_dock_widget("all")
 
 ```{code-cell} ipython3
 @magicgui(
-    auto_call=True, 
-    sigma={"widget_type": "FloatSlider", "min": 0, "max": 20})
+        auto_call=True, 
+        sigma={"widget_type": "FloatSlider", "min": 0, "max": 20}
+        )
 def gaussian_high_pass(
         image: "napari.types.ImageData", sigma: float = 2
         ) -> "napari.types.ImageData":

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -285,7 +285,7 @@ def detect_spots(
         high_pass_sigma: float = 2,
         spot_threshold: float = 0.2,
         blob_sigma: float = 2
-        )->"napari.types.LayerDataTuple":
+        ) -> "napari.types.LayerDataTuple":
     """Apply a gaussian high pass filter to an image.
 
     Parameters

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -96,7 +96,9 @@ For more information, see the official Python documentation for:
 from magicgui import magicgui
 
 @magicgui
-def gaussian_high_pass(image: "napari.types.ImageData", sigma: float = 2)->"napari.types.ImageData":
+def gaussian_high_pass(
+        image: "napari.types.ImageData", sigma: float = 2
+        ) -> "napari.types.ImageData":
     """Apply a gaussian high pass filter to an image.
 
     Parameters
@@ -197,7 +199,9 @@ viewer.window.remove_dock_widget("all")
 @magicgui(auto_call=True,
             sigma={"widget_type": "FloatSlider", "min": 0, "max": 20}
          )
-def gaussian_high_pass(image: "napari.types.ImageData", sigma: float = 2)->"napari.types.ImageData":
+def gaussian_high_pass(
+        image: "napari.types.ImageData", sigma: float = 2
+        ) -> "napari.types.ImageData":
     """Apply a gaussian high pass filter to an image.
 
     Parameters


### PR DESCRIPTION
For my workshop I split up the spot detection workshop into a real basics one and then an interactivity one (magicgui, bind_key). I think this can be useful to someone else so I'm throwing these in, but not linking in the ToC.