### PR TITLE
Update binder config and instructions

### DIFF
--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -7,7 +7,6 @@ xorg
 xubuntu-icon-theme
 tigervnc-standalone-server
 tigervnc-xorg-extension
-dbus-x11
 libegl1
 libx11-xcb-dev
 libglu1-mesa-dev

--- a/binder/apt.txt
+++ b/binder/apt.txt
@@ -1,11 +1,14 @@
 dbus-x11
-firefox
 xfce4
 xfce4-panel
 xfce4-session
 xfce4-settings
 xorg
 xubuntu-icon-theme
+tigervnc-standalone-server
+tigervnc-xorg-extension
+dbus-x11
+libegl1
 libx11-xcb-dev
 libglu1-mesa-dev
 libxrender-dev

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -2,11 +2,14 @@ name: binder
 channels:
   - conda-forge
 dependencies:
-  - python=3.9
-  - jupyter-server-proxy>=1.4
+  - python=3.11
+  - jupyterlab
   - jupytext
-  - pip
+  - jupyterlab-myst
+  - napari
+  - pyqt
+  - jupyter-book
   - websockify
-  - libxcb
+  - pip
   - pip:
-    - jupyter-desktop-server
+    - jupyter-remote-desktop-proxy

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-pip install -r requirements.txt

--- a/napari-workshops/_config.yml
+++ b/napari-workshops/_config.yml
@@ -9,7 +9,7 @@ logo: logo.ico
 only_build_toc_files: true
 
 launch_buttons:
-  notebook_interface : classic  # The interface interactive links will activate ["classic", "jupyterlab"]
+  notebook_interface : "jupyterlab"  # The interface interactive links will activate ["classic", "jupyterlab"]
   binderhub_url : https://mybinder.org  # The URL of the BinderHub (e.g., https://mybinder.org)
 
 # Force re-execution of notebooks on each build.

--- a/napari-workshops/docs/launching_binder.md
+++ b/napari-workshops/docs/launching_binder.md
@@ -1,20 +1,26 @@
-# How to open your notebooks using [mybinder.org](https://mybinder.org)
+# How to open the notebooks in the cloud using [mybinder.org](https://mybinder.org)
 
-If you can't install the Jupyter notebook application locally, or if you prefer using a cloud instance of Jupyter to execute and interact with your workshop notebooks, you can follow this guide.
+If you can't install napari and the Jupyter notebook application locally, or if you prefer using a cloud instance of Jupyter to execute and interact with the workshop notebooks, you can follow this guide.
+
+```{note}
+Because this will launch a virtual machine in the cloud and install everything needed to run the notebook, it could take *several minutes* to spin up!
+```
 
 ## Open a single notebook in Binder
 
-To open a single notebook in Binder, click the rocketship badge at the top of each notebook, and click on "Binder".
+To open a notebook in Binder, click on the rocketship badge at the top of a notebook and click on "Binder".
 
 ![Binder badge shown in the "Bioimage visualization in Python" notebook](./images/binder_button.png)
 
+This will open the notebook in Markdown format, but it will not be runnable. Further, because napari is a desktop application, we need a "Desktop" tab to see the napari GUI interface. To do this, close the Markdown notebook and return to the Jupyter launcher.
+
 ## Open desktop tab
 
-Because napari is a desktop application, we need a "Desktop" tab to see the napari GUI interface. In the Jupyter launcher tab, click on "Desktop".
+In the Jupyter launcher tab, click on the "Desktop" tile.
 
 ![Desktop tab button in Jupyter launcher tab](./images/desktop_tab.png)
 
-After this, you should see a new tab open up in your browser window called "noVNC", with a basic desktop interface.
+After this, you should see a new tab open up in your browser window called "Jupyter Remote Desktop Proxy", with a basic Linux desktop interface. Note if at first it doesn't connect, just close the tab and click the `D` tile a second time.
 
 ![Desktop interface shown in browser tab](./images/desktop.png)
 
@@ -22,20 +28,22 @@ By moving your mouse pointer inside this desktop interface, you should be able t
 
 ## Run notebook cells
 
-Now that our desktop is set up, we can proceed to running each of the cells in the notebooks.
+Now that our desktop is set up, we can proceed to running each of the cells in the notebook. You can access them from the file browser on the left side, in the `notebooks` folder.
 
-To open a notebook from this Jupyter interface, right click the notebook name in the file navigation panel from the Jupyter interface, and click "Open with -> Notebook".
+```{important}
+To open these workshop notebooks in this Jupyter interface, right click the notebook name in the file navigation panel from the Jupyter interface, and click "Open with -> Notebook".
 
 ![Right click on "intro_bioimage_visualization.md" file, and select "Open with -> Notebook"](./images/open_with_notebook.png)
 
-You will note that these notebooks contain a code cell which needs to be run to enable the Binder interface. 
+Additionally, all of these notebooks contain a code cell which needs to be run to enable the napari window to be displayed in the Binder Desktop tab. 
 
 ![First code cell for all notebooks, required to run the notebooks on Binder](./images/prepare_binder.png)
+```
 
-Note that every napari operation will be shown in the desktop tab of your browser, and will only be visible in the notebook interface after the `nbscreenshot` function is called. After running any cell which opens the napari viewer from the Jupyter notebook, you should now see the napari GUI window in the Desktop tab on your browser.
+After running any cell which opens the napari viewer from the Jupyter notebook, you should now see the napari GUI window in the Desktop tab on your browser.
 
 ![napari interface in Desktop tab](./images/napari_desktop.png)
 
 ## Interact with the notebook!
 
-You should now be able to interact with this notebook, by executing all cells and observing the results in the napari GUI window. You can also edit the code cells to experiment with different napari concepts and its API.
+You should now be able to interact with this notebook, by executing all cells and observing the results in the napari GUI window. You can also edit the code cells to experiment with different napari concepts and its API. You can save a snapshot of the viewer status to the notebook using the `nbscreenshot` function.

--- a/napari-workshops/notebooks/spot_detection_functions.md
+++ b/napari-workshops/notebooks/spot_detection_functions.md
@@ -19,6 +19,19 @@ There are a number of ways to go about creating your own widgets, you can see [a
 
 In this module, we will implement elements of our previous workflow as functions and then use [`magicgui.magicgui`](https://pyapp-kit.github.io/magicgui/api/magicgui/#magicguimagicgui) decorator on those functions to return us compound widgets that we can use to make exploring the parameters easier in the GUI. For a nice overview of the `magicgui` decorators, see [the official documentation](https://pyapp-kit.github.io/magicgui/decorators/).
 
+## `binder` setup
+
+```{code-cell} ipython3
+:tags: [remove-output]
+
+# this cell is required to run these notebooks on Binder. Make sure that you also have a desktop tab open.
+import os
+if 'BINDER_SERVICE_HOST' in os.environ:
+    os.environ['DISPLAY'] = ':1.0'
+```
+
+## Loading data
+
 Let's get everything set up, based on the previous notebook:
 
 ```{code-cell} ipython3
@@ -44,6 +57,8 @@ viewer.add_image(nuclei, colormap = 'I Forest', blending = 'minimum')
 # add the spots image to the viewer
 viewer.add_image(spots, colormap = 'I Orange', blending='minimum')
 ```
+
+## A basic filtering function
 
 Now let's write a function that takes an array and a `sigma` value and performs the 
 high-pass operation.


### PR DESCRIPTION
In this PR I update the binder setup to:
1. use `jupyter-remote-desktop-proxy` which is the actively maintained package. This involves some changes to the apt requirements
2. use conda for the whole setup, rather than mixing a pip `postBuild` this makes it a bit faster. Also bump to python 3.11
3. use `jupyterlab` interface as the binder default--this matches the overall workshop flow so it makes it easier on the user

Then I update the binder notebook instructions to account for the use of jupyterlab out of the box.
Finally, I add the binder setup cell to the functions notebook.

I implemented these changes first in my I2K repo, so you can test it out here:
https://psobolewskiphd.github.io/i2k2024_napari_workshop/notebooks/spot_detection.html